### PR TITLE
Fixes for a working build, and to remove the InnerBand pod

### DIFF
--- a/Classes/Controllers/CurrentGamesController.m
+++ b/Classes/Controllers/CurrentGamesController.m
@@ -12,7 +12,6 @@
 #import "SpinnerView.h"
 #import "GameViewController.h"
 #import "InviteViewController.h"
-#import "IBAlertView.h"
 #import "LoadingCell.h"
 #import "DGSPushServer.h"
 #import "Invite.h"
@@ -156,9 +155,20 @@ typedef NS_ENUM(NSUInteger, GameSection) {
 }
 
 - (IBAction)logout {
-    [IBAlertView showAlertWithTitle:@"Logout?" message:@"Are you sure you want to logout from the Dragon Go Server?" dismissTitle:@"Don't logout" okTitle:@"Logout" dismissBlock:^{
+    UIAlertController *logoutAlert = [UIAlertController alertControllerWithTitle:@"Logout?"
+                                                                         message:@"Are you sure you want to logout from the Dragon Go Server?"
+                                                                  preferredStyle:UIAlertControllerStyleAlert];
+
+    UIAlertAction *noLogoutAction = [UIAlertAction actionWithTitle:@"Don't logout"
+                                                             style:UIAlertActionStyleDefault
+                                                           handler:^(UIAlertAction * action) {
         // do nothing
-    } okBlock:^{
+    }];
+    [logoutAlert addAction:noLogoutAction];
+
+    UIAlertAction *logoutAction = [UIAlertAction actionWithTitle:@"Logout"
+                                                           style:UIAlertActionStyleDestructive
+                                                         handler:^(UIAlertAction * action) {
         [self setEnabled:NO];
         self.spinner.label.text = @"Logging out…";
         [self.spinner show];
@@ -167,6 +177,9 @@ typedef NS_ENUM(NSUInteger, GameSection) {
             [self.spinner dismiss:YES];
         }];
     }];
+    [logoutAlert addAction:logoutAction];
+    
+    [self presentViewController:logoutAlert animated:YES completion:nil];
 }
 
 - (IBAction)gameListTypeChanged:(id)sender {

--- a/Classes/Controllers/CurrentGamesController.m
+++ b/Classes/Controllers/CurrentGamesController.m
@@ -160,7 +160,7 @@ typedef NS_ENUM(NSUInteger, GameSection) {
                                                                   preferredStyle:UIAlertControllerStyleAlert];
 
     UIAlertAction *noLogoutAction = [UIAlertAction actionWithTitle:@"Don't logout"
-                                                             style:UIAlertActionStyleDefault
+                                                             style:UIAlertActionStyleCancel
                                                            handler:^(UIAlertAction * action) {
         // do nothing
     }];

--- a/Classes/Controllers/GameViewController.m
+++ b/Classes/Controllers/GameViewController.m
@@ -14,7 +14,6 @@
 #import "SpinnerView.h"
 #import "NSTimer+Blocks.h"
 #import "DGSPushServer.h"
-#import "IBAlertView.h"
 
 @interface GameViewController ()
 
@@ -89,12 +88,29 @@ const NSTimeInterval kDefaultResignTimerLength = 1.0;
     self.sgfShareQueue.name = @"SGF saving queue";
 
     if ([theBoard size] > [FuegoBoard maximumSupportedBoardSize]) {
-        [IBAlertView showAlertWithTitle:nil message:S(@"Games larger than %dx%d can't be played in this app. Would you like to open this game in a browser instead?", [FuegoBoard maximumSupportedBoardSize], [FuegoBoard maximumSupportedBoardSize]) dismissTitle:@"Don't Open" okTitle:@"Open" dismissBlock:^{
-                [self.navigationController popViewControllerAnimated:YES];
-            } okBlock:^{
-                [[GenericGameServer sharedGameServer] openGameInBrowser:self.game];
-                [self.navigationController popViewControllerAnimated:YES];
-            }];
+        UIAlertController *tooLargeAlert =
+            [UIAlertController alertControllerWithTitle:nil
+                                                message:S(@"Games larger than %dx%d can't be played in this app. Would you like to open this game in a browser instead?", [FuegoBoard maximumSupportedBoardSize], [FuegoBoard maximumSupportedBoardSize])
+                                         preferredStyle:UIAlertControllerStyleAlert];
+        
+        UIAlertAction *noOpenAction =
+            [UIAlertAction actionWithTitle:@"Don't Open"
+                                     style:UIAlertActionStyleDefault
+                                   handler:^(UIAlertAction * action) {
+                                       [self.navigationController popViewControllerAnimated:YES];
+                                   }];
+        [tooLargeAlert addAction:noOpenAction];
+        
+        UIAlertAction *openAction =
+            [UIAlertAction actionWithTitle:@"Open"
+                                     style:UIAlertActionStyleDefault
+                                   handler:^(UIAlertAction * action) {
+                                       [[GenericGameServer sharedGameServer] openGameInBrowser:self.game];
+                                       [self.navigationController popViewControllerAnimated:YES];
+                                   }];
+        [tooLargeAlert addAction:openAction];
+        
+        [self presentViewController:tooLargeAlert animated:YES completion:nil];
     }
 }
 

--- a/Classes/Controllers/GameViewController.m
+++ b/Classes/Controllers/GameViewController.m
@@ -95,7 +95,7 @@ const NSTimeInterval kDefaultResignTimerLength = 1.0;
         
         UIAlertAction *noOpenAction =
             [UIAlertAction actionWithTitle:@"Don't Open"
-                                     style:UIAlertActionStyleDefault
+                                     style:UIAlertActionStyleCancel
                                    handler:^(UIAlertAction * action) {
                                        [self.navigationController popViewControllerAnimated:YES];
                                    }];

--- a/Classes/Controllers/GameViewController.m
+++ b/Classes/Controllers/GameViewController.m
@@ -427,7 +427,7 @@ const NSTimeInterval kDefaultResignTimerLength = 1.0;
         BOOL isZoomedIn = [self isSmallBoard] || self.boardState == kBoardStateZoomedIn;
         BOOL canPlayOrMarkStones = !self.readOnly && canPlaceStones && isZoomedIn;
         
-        NSLog(@"Zoom State: %d %d %d %d %d %d", [self.board canPlayMove], [self.board gameEnded], [self.board beforeCurrentMove], self.readOnly, [self isSmallBoard], self.boardState);
+        NSLog(@"Zoom State: %d %d %d %d %d %ld", [self.board canPlayMove], [self.board gameEnded], [self.board beforeCurrentMove], self.readOnly, [self isSmallBoard], (long)self.boardState);
         
         if (shouldZoomIn) {
             [self zoomIn:[sender locationInView:self.boardView]];

--- a/Classes/Controllers/JoinWaitingRoomGameController.m
+++ b/Classes/Controllers/JoinWaitingRoomGameController.m
@@ -1,6 +1,5 @@
 
 #import "JoinWaitingRoomGameController.h"
-#import "IBAlertView.h"
 #import "SpinnerView.h"
 #import "ExpandingLabelCell.h"
 
@@ -152,17 +151,33 @@
     if (![self isPropertyCell:indexPath.section]) {
         [tableView deselectRowAtIndexPath:indexPath animated:YES];
         if (self.game.myGame) {
-            [IBAlertView showAlertWithTitle:@"Delete?" message:@"Are you sure you want to delete this game from the server?" dismissTitle:@"Don't delete" okTitle:@"Delete" dismissBlock:^{
-            } okBlock:^{
-                self.spinner.label.text = @"Deleting…";
-                [self.spinner show];
-                [[GenericGameServer sharedGameServer] deleteWaitingRoomGame:self.game.gameId onSuccess:^() {
-                    [self.spinner dismiss:YES];
-                    [self.navigationController popViewControllerAnimated:YES];
-                } onError:^(NSError *error) {
-                    [self.spinner dismiss:YES];
-                }];
-            }];
+            UIAlertController *confirmDeleteAlert =
+            [UIAlertController alertControllerWithTitle:@"Delete?"
+                                                message:@"Are you sure you want to delete this game from the server?"
+                                         preferredStyle:UIAlertControllerStyleAlert];
+            
+            UIAlertAction *noDeleteAction =
+            [UIAlertAction actionWithTitle:@"Don't delete"
+                                     style:UIAlertActionStyleDefault
+                                   handler:^(UIAlertAction * action) {}];
+            [confirmDeleteAlert addAction:noDeleteAction];
+            
+            UIAlertAction *deleteAction =
+            [UIAlertAction actionWithTitle:@"Delete"
+                                     style:UIAlertActionStyleDestructive
+                                   handler:^(UIAlertAction * action) {
+                                       self.spinner.label.text = @"Deleting…";
+                                       [self.spinner show];
+                                       [[GenericGameServer sharedGameServer] deleteWaitingRoomGame:self.game.gameId onSuccess:^() {
+                                           [self.spinner dismiss:YES];
+                                           [self.navigationController popViewControllerAnimated:YES];
+                                       } onError:^(NSError *error) {
+                                           [self.spinner dismiss:YES];
+                                       }];
+                                   }];
+            [confirmDeleteAlert addAction:deleteAction];
+            
+            [self presentViewController:confirmDeleteAlert animated:YES completion:nil];
         } else {
             self.spinner.label.text = @"Joining…";
             [[GenericGameServer sharedGameServer] joinWaitingRoomGame:self.game.gameId onSuccess:^{

--- a/Classes/Controllers/JoinWaitingRoomGameController.m
+++ b/Classes/Controllers/JoinWaitingRoomGameController.m
@@ -158,7 +158,7 @@
             
             UIAlertAction *noDeleteAction =
             [UIAlertAction actionWithTitle:@"Don't delete"
-                                     style:UIAlertActionStyleDefault
+                                     style:UIAlertActionStyleCancel
                                    handler:^(UIAlertAction * action) {}];
             [confirmDeleteAlert addAction:noDeleteAction];
             

--- a/Classes/Models/FuegoBoard.mm
+++ b/Classes/Models/FuegoBoard.mm
@@ -8,15 +8,15 @@
 //
 
 #import "FuegoBoard.h"
-#import "SgSystem.h"
-#import "SgNode.h"
-#import "GoGame.h"
-#import "SgInit.h"
-#import "GoInit.h"
-#import "SgGameReader.h"
-#import "GoModBoard.h"
-#import "GoRegionBoard.h"
-#import "GoBlock.h"
+#import <fuego/SgSystem.h>
+#import <fuego/SgNode.h>
+#import <fuego/GoGame.h>
+#import <fuego/SgInit.h>
+#import <fuego/GoInit.h>
+#import <fuego/SgGameReader.h>
+#import <fuego/GoModBoard.h>
+#import <fuego/GoRegionBoard.h>
+#import <fuego/GoBlock.h>
 #include <sstream>
 
 static bool fuegoInitialized = NO;

--- a/Classes/Models/GameList.h
+++ b/Classes/Models/GameList.h
@@ -5,7 +5,14 @@
 #import <Foundation/Foundation.h>
 @class Game;
 
-@interface GameList : NSObject <NSCoding, NSCopying, NSMutableCopying>
+@interface GameList : NSObject <NSCoding, NSCopying, NSMutableCopying> {
+@protected
+    NSOrderedSet *_games;
+    NSOrderedSet *_invites;
+    NSString *_pathFormat;
+    BOOL _hasMorePages;
+    int _offset;
+}
 
 @property(nonatomic, copy, readonly) NSOrderedSet *games;
 @property(nonatomic, copy, readonly) NSOrderedSet *invites;

--- a/Classes/Models/GameList.m
+++ b/Classes/Models/GameList.m
@@ -130,7 +130,7 @@
 // confident these are needed, and when I have tests up and running, I'd like
 // to add some tests to see one way or the other. These are an effort to
 // correctly respond to the compiler warnings I'm seeing, but they might be
-// superfluous.
+// superfluous.)
 
 - (void)setPathFormat:(NSString *)pathFormat {
     _pathFormat = pathFormat;

--- a/Classes/Models/GameList.m
+++ b/Classes/Models/GameList.m
@@ -99,6 +99,8 @@
 
 @implementation MutableGameList
 
+@dynamic games, invites, pathFormat, hasMorePages, offset;
+
 - (void)removeGame:(Game *)game {
     NSMutableOrderedSet *mutableGames = [self.games mutableCopy];
     [mutableGames removeObject:game];
@@ -117,13 +119,30 @@
     _invites = mutableInvites;
 }
 
-
 - (void)addInvites:(NSOrderedSet *)moreInvites {
     NSMutableOrderedSet *mutableInvites = [self.invites mutableCopy];
     [mutableInvites unionOrderedSet:moreInvites];
     _invites = mutableInvites;
 }
 
+// Adding implementations of setters since these properties are synthesized
+// in the superclass, where they are declared as readonly. (NOTE: I'm not
+// confident these are needed, and when I have tests up and running, I'd like
+// to add some tests to see one way or the other. These are an effort to
+// correctly respond to the compiler warnings I'm seeing, but they might be
+// superfluous.
+
+- (void)setPathFormat:(NSString *)pathFormat {
+    _pathFormat = pathFormat;
+}
+
+- (void)setHasMorePages:(BOOL)hasMorePages {
+    _hasMorePages = hasMorePages;
+}
+
+- (void)setOffset:(int)offset {
+    _offset = offset;
+}
 
 - (id)copyWithZone:(NSZone *)zone {
     return [[GameList allocWithZone:zone] initWithGames:self.games

--- a/Classes/Models/GameList.m
+++ b/Classes/Models/GameList.m
@@ -102,26 +102,26 @@
 - (void)removeGame:(Game *)game {
     NSMutableOrderedSet *mutableGames = [self.games mutableCopy];
     [mutableGames removeObject:game];
-    self.games = mutableGames;
+    _games = mutableGames;
 }
 
 - (void)addGames:(NSOrderedSet *)moreGames {
     NSMutableOrderedSet *mutableGames = [self.games mutableCopy];
     [mutableGames unionOrderedSet:moreGames];
-    self.games = mutableGames;
+    _games = mutableGames;
 }
 
 - (void)removeInvite:(Invite *)invite {
     NSMutableOrderedSet *mutableInvites = [self.invites mutableCopy];
     [mutableInvites removeObject:invite];
-    self.invites = mutableInvites;
+    _invites = mutableInvites;
 }
 
 
 - (void)addInvites:(NSOrderedSet *)moreInvites {
     NSMutableOrderedSet *mutableInvites = [self.invites mutableCopy];
     [mutableInvites unionOrderedSet:moreInvites];
-    self.invites = mutableInvites;
+    _invites = mutableInvites;
 }
 
 

--- a/Classes/Table Cells/SelectCell.m
+++ b/Classes/Table Cells/SelectCell.m
@@ -65,7 +65,7 @@
         self.picker.delegate = self;
         
         for(int i = 0; i < [self.selectedOptions count]; i++) {
-            int row = [(self.options)[i] indexOfObject:(self.selectedOptions)[i]];
+            int row = (int)[(self.options)[i] indexOfObject:(self.selectedOptions)[i]];
             [self.picker selectRow:row inComponent:i animated:NO];
         }
     }

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,6 @@ xcodeproj 'DGSPhone.xcodeproj'
 
 pod 'GDataXML-HTML', '~> 1.0.0'
 pod 'ODRefreshControl'
-pod 'InnerBand'
 pod 'MKNetworkKit'
 pod 'boost-framework', :podspec => 'boost-framework.podspec'
 pod 'fuego-framework', :podspec => 'fuego-framework.podspec'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,7 +24,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   boost-framework: 191ccc21b8ae4424de2e2d4aee7964ec116af0fb
-  fuego-framework: 59741807a0d8e1e549e7b11362eb499fdffc9f84
+  fuego-framework: 21ff216bb51fd9701e55ea6aa1566ca6c7ef3cf8
   GDataXML-HTML: 40fb2f0ddb189d5a7c8c141a521a75e993bc3dfc
   InnerBand: 9af0750298039829dc9f278a1c3e1bd66b5366b7
   MKNetworkKit: 60ad3c83b62183e40ba75ce772c9427c25b520de

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,6 @@ PODS:
   - boost-framework (1.51.0)
   - fuego-framework (1.1)
   - GDataXML-HTML (1.0.0)
-  - InnerBand (1.0.6)
   - MKNetworkKit (0.87):
     - Reachability (~> 3.1.0)
   - ODRefreshControl (1.2)
@@ -12,7 +11,6 @@ DEPENDENCIES:
   - boost-framework (from `boost-framework.podspec`)
   - fuego-framework (from `fuego-framework.podspec`)
   - GDataXML-HTML (~> 1.0.0)
-  - InnerBand
   - MKNetworkKit
   - ODRefreshControl
 
@@ -26,7 +24,6 @@ SPEC CHECKSUMS:
   boost-framework: 191ccc21b8ae4424de2e2d4aee7964ec116af0fb
   fuego-framework: 21ff216bb51fd9701e55ea6aa1566ca6c7ef3cf8
   GDataXML-HTML: 40fb2f0ddb189d5a7c8c141a521a75e993bc3dfc
-  InnerBand: 9af0750298039829dc9f278a1c3e1bd66b5366b7
   MKNetworkKit: 60ad3c83b62183e40ba75ce772c9427c25b520de
   ODRefreshControl: 907e6149d72dde488d5917ccfabee5bd8d711a20
   Reachability: dd9aa4fb6667b9f787690a74f53cb7634ce99893

--- a/acknowledgements.html
+++ b/acknowledgements.html
@@ -52,20 +52,6 @@ p {
 
 <p>This application makes use of the following third party libraries:</p>
 
-<h2>InnerBand</h2>
-
-<p>Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at</p>
-
-<p>http://www.apache.org/licenses/LICENSE-2.0</p>
-
-<p>Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.</p>
-
 <h2>MKNetworkKit</h2>
 
 <p>MKNetworkKit is licensed under MIT License

--- a/fuego-framework.podspec
+++ b/fuego-framework.podspec
@@ -179,8 +179,8 @@ END
   s.source             = { :http => 'https://s3.amazonaws.com/justinweiss/fuego.framework.zip' }
   s.platform           = :ios, '5.0'
 
-  s.ios.frameworks     =  'boost', 'fuego'
-  s.ios.source_files   =  "fuego.framework/Versions/A/Headers/*.h"
-  s.ios.xcconfig       =  { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/fuego-framework"' }
-  s.ios.preserve_paths =  'fuego.framework'
+  s.ios.frameworks          =  'boost', 'fuego'
+  s.ios.public_header_files =  "fuego.framework/Headers/*.h"
+  s.ios.xcconfig            =  { 'FRAMEWORK_SEARCH_PATHS' => '"$(PODS_ROOT)/fuego-framework"' }
+  s.ios.preserve_paths      =  'fuego.framework'
 end


### PR DESCRIPTION
This PR contains some commits to get to a working build, and then some more to remove the InnerBand pod from the product. One build error is resolved, and the warning count went from 149 to 33 with the removal of InnerBand.

InnerBand was lightly used (to generate three alert dialogs) and was easy to replace with UIAlertController in newer iOS releases, which works almost identically. If you have InnerBand installed already, after this pull you can remove it by re-running `bootstrap.sh` in the main repo directory.

Let me know if anything about this is not what you'd prefer. Thanks!